### PR TITLE
fix work-area width

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
 
         <!-- START WORK DESIGN AREA -->
     <section id="work" class="work section-padding">
-        <div class="container-fluid">
+        <div class="container">
             <div class="row">
                 <div class="col-sm-12">
                     <div class="section-title">


### PR DESCRIPTION
Fixed the width of the container for the portfolio grid, instead of `container-fluid`, simple `container` is used as class